### PR TITLE
Reimplemented waitForPullRequestReview to check for reviewer activity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,10 @@ require (
 	github.com/stretchr/testify v1.10.0
 )
 
-require github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 // indirect
+require (
+	github.com/ccoveille/go-safecast v1.6.1 // indirect
+	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 // indirect
+)
 
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.7
 
 require (
 	github.com/aws/smithy-go v1.22.3
+	github.com/ccoveille/go-safecast v1.6.1
 	github.com/docker/docker v28.0.4+incompatible
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v69 v69.2.0
@@ -16,10 +17,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 )
 
-require (
-	github.com/ccoveille/go-safecast v1.6.1 // indirect
-	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 // indirect
-)
+require github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 // indirect
 
 require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/aws/smithy-go v1.22.3 h1:Z//5NuZCSW6R4PhQ93hShNbyBbn8BWCmCVCt+Q8Io5k=
 github.com/aws/smithy-go v1.22.3/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
+github.com/ccoveille/go-safecast v1.6.1 h1:Nb9WMDR8PqhnKCVs2sCB+OqhohwO5qaXtCviZkIff5Q=
+github.com/ccoveille/go-safecast v1.6.1/go.mod h1:QqwNjxQ7DAqY0C721OIO9InMk9zCwcsO7tnRuHytad8=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=

--- a/pkg/github/pullrequest_events.go
+++ b/pkg/github/pullrequest_events.go
@@ -30,8 +30,59 @@ type PullRequestEventContext struct {
 	PollInterval  time.Duration
 }
 
+// PullRequestActivityQuery represents the GraphQL query structure for PR activity
+type PullRequestActivityQuery struct {
+	Repository struct {
+		PullRequest struct {
+			Commits struct {
+				Nodes []struct {
+					Commit struct {
+						Author struct {
+							Email githubv4.String
+						}
+						CommittedDate githubv4.DateTime
+					}
+				}
+			} `graphql:"commits(last: 10)"`
+			Reviews struct {
+				TotalCount githubv4.Int
+				Nodes      []struct {
+					ViewerDidAuthor githubv4.Boolean
+					State           githubv4.String
+					UpdatedAt       githubv4.DateTime
+					Comments        struct {
+						TotalCount githubv4.Int
+						Nodes      []struct {
+							ViewerDidAuthor githubv4.Boolean
+							BodyText        githubv4.String
+							UpdatedAt       githubv4.DateTime
+						}
+					} `graphql:"comments(first: 100)"`
+				}
+			} `graphql:"reviews(last: 100)"`
+			Author struct {
+				Login githubv4.String
+				Email githubv4.String
+			}
+		} `graphql:"pullRequest(number: $pr)"`
+	} `graphql:"repository(owner: $owner, name: $repo)"`
+}
+
+// ActivityResult represents the processed result of PR activity
+type ActivityResult struct {
+	ViewerDates      []string  `json:"viewerDates"`
+	ViewerMaxDate    time.Time `json:"viewerMaxDate"`
+	NonViewerDates   []string  `json:"nonViewerDates"`
+	NonViewerMaxDate time.Time `json:"nonViewerMaxDate"`
+}
+
+// GraphQLQuerier defines the minimal interface needed for GraphQL operations
+type GraphQLQuerier interface {
+	Query(ctx context.Context, q interface{}, variables map[string]interface{}) error
+}
+
 // waitForPullRequestReview creates a tool to wait for a new review to be added to a pull request.
-func waitForPullRequestReview(mcpServer *server.MCPServer, gh *github.Client, gql *githubv4.Client, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func waitForPullRequestReview(mcpServer *server.MCPServer, gh *github.Client, gql GraphQLQuerier, t translations.TranslationHelperFunc) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool("wait_for_pullrequest_review",
 			mcp.WithDescription(t("TOOL_WAIT_FOR_PULLREQUEST_REVIEW_DESCRIPTION", "Wait for a pull request to be approved, or for additional feedback to be added")),
 			mcp.WithString("owner",
@@ -46,9 +97,6 @@ func waitForPullRequestReview(mcpServer *server.MCPServer, gh *github.Client, gq
 				mcp.Required(),
 				mcp.Description("Pull request number"),
 			),
-			mcp.WithNumber("last_review_id",
-				mcp.Description("ID of most recent review (wait for newer reviews)"),
-			),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			// Parse common parameters and set up context
@@ -58,43 +106,115 @@ func waitForPullRequestReview(mcpServer *server.MCPServer, gh *github.Client, gq
 			}
 			defer cancel()
 
-			// Get optional last_review_id parameter
-			lastReviewID, err := optionalIntParam(request, "last_review_id")
-			if err != nil {
-				return mcp.NewToolResultError(err.Error()), nil
-			}
-
 			// Run the polling loop with a check function for pull request reviews
 			return pollForPullRequestEvent(eventCtx, func() (*mcp.CallToolResult, error) {
-				// Get the current reviews
-				reviews, resp, err := gh.PullRequests.ListReviews(eventCtx.Ctx, eventCtx.Owner, eventCtx.Repo, eventCtx.PullNumber, nil)
+				// First, get the PR to determine the author's email
+				pr, resp, err := gh.PullRequests.Get(eventCtx.Ctx, eventCtx.Owner, eventCtx.Repo, eventCtx.PullNumber)
 				if err != nil {
-					return nil, fmt.Errorf("failed to get pull request reviews: %w", err)
+					return nil, fmt.Errorf("failed to get pull request: %w", err)
 				}
 
 				// Handle the response
-				if err := handleResponse(resp, "failed to get pull request reviews"); err != nil {
+				if err := handleResponse(resp, "failed to get pull request"); err != nil {
 					return mcp.NewToolResultError(err.Error()), nil
 				}
 
-				// Check if there are any new reviews
-				var latestReview *github.PullRequestReview
-				for _, review := range reviews {
-					if review.ID == nil {
-						continue
+				if pr.User == nil || pr.User.Login == nil {
+					return mcp.NewToolResultError("Pull request author information is missing"), nil
+				}
+
+				prAuthorLogin := *pr.User.Login
+
+				// Execute GraphQL query to get PR activity
+				var query PullRequestActivityQuery
+				variables := map[string]interface{}{
+					"owner": githubv4.String(eventCtx.Owner),
+					"repo":  githubv4.String(eventCtx.Repo),
+					"pr":    githubv4.Int(eventCtx.PullNumber),
+				}
+
+				err = gql.Query(eventCtx.Ctx, &query, variables)
+				if err != nil {
+					return nil, fmt.Errorf("failed to execute GraphQL query: %w", err)
+				}
+
+				// Process the query results to find the most recent activity
+				viewerDates := []time.Time{}
+				nonViewerDates := []time.Time{}
+
+				// Process commits
+				for _, node := range query.Repository.PullRequest.Commits.Nodes {
+					commitDate := node.Commit.CommittedDate.Time
+					commitAuthorEmail := string(node.Commit.Author.Email)
+
+					// Check if the commit is from the PR author
+					if strings.Contains(commitAuthorEmail, string(prAuthorLogin)) {
+						viewerDates = append(viewerDates, commitDate)
+					} else {
+						nonViewerDates = append(nonViewerDates, commitDate)
+					}
+				}
+
+				// Process reviews
+				for _, review := range query.Repository.PullRequest.Reviews.Nodes {
+					reviewDate := review.UpdatedAt.Time
+
+					// Check if the review is from the PR author
+					if review.ViewerDidAuthor {
+						viewerDates = append(viewerDates, reviewDate)
+					} else {
+						nonViewerDates = append(nonViewerDates, reviewDate)
 					}
 
-					reviewID := int(*review.ID)
-					if reviewID > lastReviewID {
-						if latestReview == nil || reviewID > int(*latestReview.ID) {
-							latestReview = review
+					// Process review comments
+					for _, comment := range review.Comments.Nodes {
+						commentDate := comment.UpdatedAt.Time
+
+						// Check if the comment is from the PR author
+						if comment.ViewerDidAuthor {
+							viewerDates = append(viewerDates, commentDate)
+						} else {
+							nonViewerDates = append(nonViewerDates, commentDate)
 						}
 					}
 				}
 
-				// If we found a new review, return it
-				if latestReview != nil {
-					r, err := json.Marshal(latestReview)
+				// Find the most recent dates
+				var viewerMaxDate, nonViewerMaxDate time.Time
+				for _, date := range viewerDates {
+					if date.After(viewerMaxDate) {
+						viewerMaxDate = date
+					}
+				}
+
+				for _, date := range nonViewerDates {
+					if date.After(nonViewerMaxDate) {
+						nonViewerMaxDate = date
+					}
+				}
+
+				// Convert dates to strings for JSON output
+				viewerDateStrings := make([]string, len(viewerDates))
+				for i, date := range viewerDates {
+					viewerDateStrings[i] = date.Format(time.RFC3339)
+				}
+
+				nonViewerDateStrings := make([]string, len(nonViewerDates))
+				for i, date := range nonViewerDates {
+					nonViewerDateStrings[i] = date.Format(time.RFC3339)
+				}
+
+				// Check if a non-author has added information more recently than the author
+				if !nonViewerMaxDate.IsZero() && nonViewerMaxDate.After(viewerMaxDate) {
+					// A reviewer has added information more recently than the author
+					activityResult := ActivityResult{
+						ViewerDates:      viewerDateStrings,
+						ViewerMaxDate:    viewerMaxDate,
+						NonViewerDates:   nonViewerDateStrings,
+						NonViewerMaxDate: nonViewerMaxDate,
+					}
+
+					r, err := json.Marshal(activityResult)
 					if err != nil {
 						return nil, fmt.Errorf("failed to marshal response: %w", err)
 					}

--- a/pkg/github/pullrequest_events_test.go
+++ b/pkg/github/pullrequest_events_test.go
@@ -269,11 +269,11 @@ func Test_WaitForPullRequestChecks(t *testing.T) {
 
 // mockGraphQLClient is a mock implementation of GraphQLQuerier for testing
 type mockGraphQLClient struct {
-	QueryFunc func(ctx context.Context, q interface{}, variables map[string]interface{}) error
+	QueryFunc func(ctx context.Context, q any, variables map[string]any) error
 }
 
 // Query implements the GraphQLQuerier interface
-func (m *mockGraphQLClient) Query(ctx context.Context, q interface{}, variables map[string]interface{}) error {
+func (m *mockGraphQLClient) Query(ctx context.Context, q any, variables map[string]any) error {
 	if m.QueryFunc != nil {
 		return m.QueryFunc(ctx, q, variables)
 	}
@@ -309,11 +309,11 @@ func Test_WaitForPullRequestReview(t *testing.T) {
 	tests := []struct {
 		name           string
 		mockedClient   *http.Client
-		mockedGQLFunc  func(ctx context.Context, q interface{}, variables map[string]interface{}) error
+		mockedGQLFunc  func(ctx context.Context, q any, variables map[string]any) error
 		requestArgs    map[string]any
 		expectError    bool
 		expectProgress bool
-		expectedResult interface{}
+		expectedResult any
 		expectedErrMsg string
 	}{
 		// Test case 1: Reviewer activity more recent than author
@@ -325,7 +325,7 @@ func Test_WaitForPullRequestReview(t *testing.T) {
 					mockPullRequest,
 				),
 			),
-			mockedGQLFunc: func(ctx context.Context, q interface{}, variables map[string]interface{}) error {
+			mockedGQLFunc: func(ctx context.Context, q any, variables map[string]any) error {
 				// Set up the query result with reviewer activity more recent than author
 				query, ok := q.(*PullRequestActivityQuery)
 				if !ok {
@@ -387,7 +387,7 @@ func Test_WaitForPullRequestReview(t *testing.T) {
 					mockPullRequest,
 				),
 			),
-			mockedGQLFunc: func(ctx context.Context, q interface{}, variables map[string]interface{}) error {
+			mockedGQLFunc: func(ctx context.Context, q any, variables map[string]any) error {
 				// Set up the query result with author activity more recent than reviewer
 				query, ok := q.(*PullRequestActivityQuery)
 				if !ok {
@@ -449,7 +449,7 @@ func Test_WaitForPullRequestReview(t *testing.T) {
 					mockPullRequest,
 				),
 			),
-			mockedGQLFunc: func(ctx context.Context, q interface{}, variables map[string]interface{}) error {
+			mockedGQLFunc: func(ctx context.Context, q any, variables map[string]any) error {
 				return fmt.Errorf("GraphQL query failed")
 			},
 			requestArgs: map[string]any{

--- a/pkg/github/pullrequest_events_test.go
+++ b/pkg/github/pullrequest_events_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -266,6 +267,19 @@ func Test_WaitForPullRequestChecks(t *testing.T) {
 	}
 }
 
+// mockGraphQLClient is a mock implementation of GraphQLQuerier for testing
+type mockGraphQLClient struct {
+	QueryFunc func(ctx context.Context, q interface{}, variables map[string]interface{}) error
+}
+
+// Query implements the GraphQLQuerier interface
+func (m *mockGraphQLClient) Query(ctx context.Context, q interface{}, variables map[string]interface{}) error {
+	if m.QueryFunc != nil {
+		return m.QueryFunc(ctx, q, variables)
+	}
+	return nil
+}
+
 func Test_WaitForPullRequestReview(t *testing.T) {
 	// Verify tool definition once
 	mockClient := github.NewClient(nil)
@@ -279,110 +293,172 @@ func Test_WaitForPullRequestReview(t *testing.T) {
 	assert.Contains(t, tool.InputSchema.Properties, "owner")
 	assert.Contains(t, tool.InputSchema.Properties, "repo")
 	assert.Contains(t, tool.InputSchema.Properties, "pullNumber")
-	assert.Contains(t, tool.InputSchema.Properties, "last_review_id")
+	// last_review_id parameter has been removed
 	assert.ElementsMatch(t, tool.InputSchema.Required, []string{"owner", "repo", "pullNumber"})
 	// timeout_seconds parameter has been removed
 
-	// Setup mock PR reviews for success case
-	mockReviews := []*github.PullRequestReview{
-		{
-			ID:      github.Ptr(int64(201)),
-			State:   github.Ptr("APPROVED"),
-			Body:    github.Ptr("LGTM"),
-			HTMLURL: github.Ptr("https://github.com/owner/repo/pull/42#pullrequestreview-201"),
-			User: &github.User{
-				Login: github.Ptr("approver"),
-			},
-			CommitID:    github.Ptr("abcdef123456"),
-			SubmittedAt: &github.Timestamp{Time: time.Now().Add(-24 * time.Hour)},
-		},
-		{
-			ID:      github.Ptr(int64(202)),
-			State:   github.Ptr("CHANGES_REQUESTED"),
-			Body:    github.Ptr("Please address the following issues"),
-			HTMLURL: github.Ptr("https://github.com/owner/repo/pull/42#pullrequestreview-202"),
-			User: &github.User{
-				Login: github.Ptr("reviewer"),
-			},
-			CommitID:    github.Ptr("abcdef123456"),
-			SubmittedAt: &github.Timestamp{Time: time.Now().Add(-12 * time.Hour)},
-		},
-		{
-			ID:      github.Ptr(int64(203)),
-			State:   github.Ptr("APPROVED"),
-			Body:    github.Ptr("Now it looks good!"),
-			HTMLURL: github.Ptr("https://github.com/owner/repo/pull/42#pullrequestreview-203"),
-			User: &github.User{
-				Login: github.Ptr("reviewer"),
-			},
-			CommitID:    github.Ptr("abcdef789012"),
-			SubmittedAt: &github.Timestamp{Time: time.Now().Add(-1 * time.Hour)},
+	// Setup mock PR for tests
+	mockPullRequest := &github.PullRequest{
+		Number: github.Ptr(42),
+		Title:  github.Ptr("Test PR"),
+		User: &github.User{
+			Login: github.Ptr("author"),
 		},
 	}
 
 	tests := []struct {
 		name           string
 		mockedClient   *http.Client
+		mockedGQLFunc  func(ctx context.Context, q interface{}, variables map[string]interface{}) error
 		requestArgs    map[string]any
 		expectError    bool
 		expectProgress bool
-		expectedReview *github.PullRequestReview
+		expectedResult interface{}
 		expectedErrMsg string
 	}{
+		// Test case 1: Reviewer activity more recent than author
 		{
-			name: "new review found",
+			name: "reviewer activity more recent than author",
 			mockedClient: mock.NewMockedHTTPClient(
 				mock.WithRequestMatch(
-					mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
-					mockReviews,
+					mock.GetReposPullsByOwnerByRepoByPullNumber,
+					mockPullRequest,
 				),
 			),
+			mockedGQLFunc: func(ctx context.Context, q interface{}, variables map[string]interface{}) error {
+				// Set up the query result with reviewer activity more recent than author
+				query, ok := q.(*PullRequestActivityQuery)
+				if !ok {
+					return fmt.Errorf("unexpected query type")
+				}
+
+				// Set author info
+				query.Repository.PullRequest.Author.Login = "author"
+
+				// Add author commit (older)
+				authorCommit := struct {
+					Commit struct {
+						Author struct {
+							Email githubv4.String
+						}
+						CommittedDate githubv4.DateTime
+					}
+				}{}
+				authorCommit.Commit.Author.Email = "author@example.com"
+				authorCommit.Commit.CommittedDate.Time = time.Now().Add(-2 * time.Hour)
+				query.Repository.PullRequest.Commits.Nodes = append(query.Repository.PullRequest.Commits.Nodes, authorCommit)
+
+				// Add reviewer review (more recent)
+				// Create a review node with the same structure as in the query
+				reviewNode := struct {
+					ViewerDidAuthor githubv4.Boolean
+					State           githubv4.String
+					UpdatedAt       githubv4.DateTime
+					Comments        struct {
+						TotalCount githubv4.Int
+						Nodes      []struct {
+							ViewerDidAuthor githubv4.Boolean
+							BodyText        githubv4.String
+							UpdatedAt       githubv4.DateTime
+						}
+					} `graphql:"comments(first: 100)"`
+				}{}
+				reviewNode.ViewerDidAuthor = false
+				reviewNode.State = "APPROVED"
+				reviewNode.UpdatedAt.Time = time.Now().Add(-1 * time.Hour)
+				query.Repository.PullRequest.Reviews.Nodes = append(query.Repository.PullRequest.Reviews.Nodes, reviewNode)
+
+				return nil
+			},
 			requestArgs: map[string]any{
-				"owner":          "owner",
-				"repo":           "repo",
-				"pullNumber":     float64(42),
-				"last_review_id": float64(202),
+				"owner":      "owner",
+				"repo":       "repo",
+				"pullNumber": float64(42),
 			},
 			expectError:    false,
 			expectProgress: false,
-			expectedReview: mockReviews[2], // The newest review (ID 203)
+			expectedResult: &ActivityResult{},
 		},
 		{
-			name: "no new reviews",
+			name: "author activity more recent than reviewer",
 			mockedClient: mock.NewMockedHTTPClient(
 				mock.WithRequestMatch(
-					mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
-					mockReviews,
+					mock.GetReposPullsByOwnerByRepoByPullNumber,
+					mockPullRequest,
 				),
 			),
+			mockedGQLFunc: func(ctx context.Context, q interface{}, variables map[string]interface{}) error {
+				// Set up the query result with author activity more recent than reviewer
+				query, ok := q.(*PullRequestActivityQuery)
+				if !ok {
+					return fmt.Errorf("unexpected query type")
+				}
+
+				// Set author info
+				query.Repository.PullRequest.Author.Login = "author"
+
+				// Add reviewer review (older)
+				// Create a review node with the same structure as in the query
+				reviewNode := struct {
+					ViewerDidAuthor githubv4.Boolean
+					State           githubv4.String
+					UpdatedAt       githubv4.DateTime
+					Comments        struct {
+						TotalCount githubv4.Int
+						Nodes      []struct {
+							ViewerDidAuthor githubv4.Boolean
+							BodyText        githubv4.String
+							UpdatedAt       githubv4.DateTime
+						}
+					} `graphql:"comments(first: 100)"`
+				}{}
+				reviewNode.ViewerDidAuthor = false
+				reviewNode.State = "APPROVED"
+				reviewNode.UpdatedAt.Time = time.Now().Add(-2 * time.Hour)
+				query.Repository.PullRequest.Reviews.Nodes = append(query.Repository.PullRequest.Reviews.Nodes, reviewNode)
+
+				// Add author commit (more recent)
+				authorCommit := struct {
+					Commit struct {
+						Author struct {
+							Email githubv4.String
+						}
+						CommittedDate githubv4.DateTime
+					}
+				}{}
+				authorCommit.Commit.Author.Email = "author@example.com"
+				authorCommit.Commit.CommittedDate.Time = time.Now().Add(-1 * time.Hour)
+				query.Repository.PullRequest.Commits.Nodes = append(query.Repository.PullRequest.Commits.Nodes, authorCommit)
+
+				return nil
+			},
 			requestArgs: map[string]any{
-				"owner":          "owner",
-				"repo":           "repo",
-				"pullNumber":     float64(42),
-				"last_review_id": float64(203), // Already have the latest review
+				"owner":      "owner",
+				"repo":       "repo",
+				"pullNumber": float64(42),
 			},
 			expectError:    true,
 			expectedErrMsg: "Timeout waiting for",
 		},
 
 		{
-			name: "reviews fetch fails",
+			name: "GraphQL query fails",
 			mockedClient: mock.NewMockedHTTPClient(
-				mock.WithRequestMatchHandler(
-					mock.GetReposPullsReviewsByOwnerByRepoByPullNumber,
-					http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-						w.WriteHeader(http.StatusNotFound)
-						_, _ = w.Write([]byte(`{"message": "Not Found"}`))
-					}),
+				mock.WithRequestMatch(
+					mock.GetReposPullsByOwnerByRepoByPullNumber,
+					mockPullRequest,
 				),
 			),
+			mockedGQLFunc: func(ctx context.Context, q interface{}, variables map[string]interface{}) error {
+				return fmt.Errorf("GraphQL query failed")
+			},
 			requestArgs: map[string]any{
 				"owner":      "owner",
 				"repo":       "repo",
-				"pullNumber": float64(999),
+				"pullNumber": float64(42),
 			},
 			expectError:    true,
-			expectedErrMsg: "failed to get pull request reviews",
+			expectedErrMsg: "failed to execute GraphQL query",
 		},
 	}
 
@@ -391,7 +467,7 @@ func Test_WaitForPullRequestReview(t *testing.T) {
 			// Setup client with mock
 			client := github.NewClient(tc.mockedClient)
 			// Create a mock githubv4.Client for each test case
-			mockGQLClient := &githubv4.Client{}
+			mockGQLClient := &mockGraphQLClient{QueryFunc: tc.mockedGQLFunc}
 			mockServer := server.NewMCPServer("test", "1.0.0")
 			_, handler := waitForPullRequestReview(mockServer, client, mockGQLClient, translations.NullTranslationHelper)
 
@@ -420,14 +496,21 @@ func Test_WaitForPullRequestReview(t *testing.T) {
 			require.NoError(t, err)
 			textContent := getTextResult(t, result)
 
-			// For completed responses, unmarshal and verify the review
-			var returnedReview github.PullRequestReview
-			err = json.Unmarshal([]byte(textContent.Text), &returnedReview)
-			require.NoError(t, err)
-			assert.Equal(t, *tc.expectedReview.ID, *returnedReview.ID)
-			assert.Equal(t, *tc.expectedReview.State, *returnedReview.State)
-			assert.Equal(t, *tc.expectedReview.Body, *returnedReview.Body)
-			assert.Equal(t, *tc.expectedReview.User.Login, *returnedReview.User.Login)
+			// For completed responses, unmarshal and verify the result
+			if tc.expectedResult != nil {
+				var returnedActivity ActivityResult
+				err = json.Unmarshal([]byte(textContent.Text), &returnedActivity)
+				require.NoError(t, err)
+
+				// Verify the activity result has the expected structure
+				assert.NotEmpty(t, returnedActivity.ViewerDates)
+				assert.NotEmpty(t, returnedActivity.NonViewerDates)
+				assert.False(t, returnedActivity.ViewerMaxDate.IsZero())
+				assert.False(t, returnedActivity.NonViewerMaxDate.IsZero())
+
+				// Verify that non-viewer date is more recent than viewer date
+				assert.True(t, returnedActivity.NonViewerMaxDate.After(returnedActivity.ViewerMaxDate))
+			}
 		})
 	}
 }

--- a/pkg/github/pullrequest_events_test.go
+++ b/pkg/github/pullrequest_events_test.go
@@ -325,7 +325,7 @@ func Test_WaitForPullRequestReview(t *testing.T) {
 					mockPullRequest,
 				),
 			),
-			mockedGQLFunc: func(ctx context.Context, q any, variables map[string]any) error {
+			mockedGQLFunc: func(_ context.Context, q any, _ map[string]any) error {
 				// Set up the query result with reviewer activity more recent than author
 				query, ok := q.(*PullRequestActivityQuery)
 				if !ok {
@@ -387,7 +387,7 @@ func Test_WaitForPullRequestReview(t *testing.T) {
 					mockPullRequest,
 				),
 			),
-			mockedGQLFunc: func(ctx context.Context, q any, variables map[string]any) error {
+			mockedGQLFunc: func(_ context.Context, q any, _ map[string]any) error {
 				// Set up the query result with author activity more recent than reviewer
 				query, ok := q.(*PullRequestActivityQuery)
 				if !ok {
@@ -449,7 +449,7 @@ func Test_WaitForPullRequestReview(t *testing.T) {
 					mockPullRequest,
 				),
 			),
-			mockedGQLFunc: func(ctx context.Context, q any, variables map[string]any) error {
+			mockedGQLFunc: func(_ context.Context, _ any, _ map[string]any) error {
 				return fmt.Errorf("GraphQL query failed")
 			},
 			requestArgs: map[string]any{


### PR DESCRIPTION
## Description

This PR reimplements the `waitForPullRequestReview` function to check for reviewer activity rather than just looking for new reviews by ID.

### Changes

- Added a new `GraphQLQuerier` interface to abstract the GraphQL client
- Implemented a GraphQL query to fetch PR activity (commits, reviews, comments)
- Added logic to determine if a non-author has added information more recently than the author
- Updated tests to verify the new implementation
- Removed the `last_review_id` parameter as it's no longer needed

Fixes #3

### Testing

All tests are passing, including the new tests for the updated implementation.

May the divine code guide our path! 🙏