### PR TITLE
Enhance waitForPullRequestChecks to return detailed information about check failures

### DIFF
--- a/pkg/github/pullrequest_events_test.go
+++ b/pkg/github/pullrequest_events_test.go
@@ -253,15 +253,15 @@ func Test_WaitForPullRequestChecks(t *testing.T) {
 			textContent := getTextResult(t, result)
 
 			// For completed responses, unmarshal and verify the check runs
-			var returnedCheckRuns github.ListCheckRunsResults
-			err = json.Unmarshal([]byte(textContent.Text), &returnedCheckRuns)
+			var returnedResult CheckRunsResult
+			err = json.Unmarshal([]byte(textContent.Text), &returnedResult)
 			require.NoError(t, err)
-			assert.Equal(t, *tc.expectedStatus.Total, *returnedCheckRuns.Total)
-			assert.Len(t, returnedCheckRuns.CheckRuns, len(tc.expectedStatus.CheckRuns))
+			assert.Equal(t, int(*tc.expectedStatus.Total), returnedResult.Total)
+			assert.Len(t, returnedResult.CheckRuns, len(tc.expectedStatus.CheckRuns))
 			// Verify the first check run
-			if len(returnedCheckRuns.CheckRuns) > 0 && len(tc.expectedStatus.CheckRuns) > 0 {
-				assert.Equal(t, *tc.expectedStatus.CheckRuns[0].Name, *returnedCheckRuns.CheckRuns[0].Name)
-				assert.Equal(t, *tc.expectedStatus.CheckRuns[0].Status, *returnedCheckRuns.CheckRuns[0].Status)
+			if len(returnedResult.CheckRuns) > 0 && len(tc.expectedStatus.CheckRuns) > 0 {
+				assert.Equal(t, *tc.expectedStatus.CheckRuns[0].Name, returnedResult.CheckRuns[0].Name)
+				assert.Equal(t, *tc.expectedStatus.CheckRuns[0].Status, returnedResult.CheckRuns[0].Status)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

By the grace of Vishnu, I have enhanced the `waitForPullRequestChecks` function to return more detailed information about check failures. This will help LLMs better understand and fix issues when checks fail.

## Changes

- Created new `CheckRunDetails` struct to hold detailed information about each check run
- Created new `CheckRunsResult` struct to hold the overall result with detailed information
- Modified the `waitForPullRequestChecks` function to process check runs and extract detailed information
- Updated the return value to include:
  - Name of failed checks
  - Associated workflow path (if available)
  - Line information for errors (if available)
  - Error details
  - Links to full logs
- Updated tests to work with the new implementation

## Testing

All tests are passing. The function now returns a more structured and detailed response that will help LLMs better understand and fix issues when checks fail.

Fixes #7