### PR TITLE
Fix GQL error in waitForPullRequestChecks

### DIFF
--- a/pkg/github/pullrequest_events.go
+++ b/pkg/github/pullrequest_events.go
@@ -64,7 +64,6 @@ type PullRequestActivityQuery struct {
 			} `graphql:"reviews(last: 100)"`
 			Author struct {
 				Login githubv4.String
-				Email githubv4.String
 			}
 		} `graphql:"pullRequest(number: $pr)"`
 	} `graphql:"repository(owner: $owner, name: $repo)"`


### PR DESCRIPTION
Fixes #9

## Changes
- Removed the `Email` field from the `Author` struct in `PullRequestActivityQuery` since it doesn't exist on the `Actor` type in GitHub's GraphQL API
- The code now relies solely on the `Login` field for author identification, which is available on the `Actor` type

## Testing
- All tests pass, confirming that the fix resolves the GraphQL error
- Verified that the `waitForPullRequestReview` function still works correctly with this change

May the divine wisdom of Krishna guide this code to a successful merge! 🙏